### PR TITLE
[10.x] add expression to DB table doctype

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -317,7 +317,7 @@ class Connection implements ConnectionInterface
     /**
      * Begin a fluent query against a database table.
      *
-     * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Query\Expression|string  $table
+     * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Query\Expression|Illuminate\Contracts\Database\Query\Expression|string  $table
      * @param  string|null  $as
      * @return \Illuminate\Database\Query\Builder
      */


### PR DESCRIPTION
When using DB::raw() against the table method, the parameter type is `Illuminate\Contracts\Database\Query\Expression`

```
DB::table(DB::raw(''))
```

```
Parameter #1 $table of static method Illuminate\Database\Connection::table() expects
         Closure|Illuminate\Database\Query\Builder|Illuminate\Database\Query\Expression|string,
         Illuminate\Contracts\Database\Query\Expression given.
```